### PR TITLE
fixed bug - domains with fcrdns were being rejected

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,12 @@ exports.check_fcrdns = function (connection, results, next) {
         }
 
         // FCrDNS? PTR -> (A | AAAA) 3. PTR comparison
-        plugin.ptr_compare(results[fdom], connection, fdom)
+        if (Array.isArray(results[fdom])) {
+            plugin.ptr_compare(results[fdom], connection, fdom)
+        }
+        else {
+            plugin.ptr_compare([results[fdom]], connection, fdom)
+        }
 
         connection.results.add(plugin, {ptr_name_has_ips: true})
 
@@ -223,7 +228,7 @@ exports.check_fcrdns = function (connection, results, next) {
 
     const r = connection.results.get('fcrdns')
     if (!r) return next()
-    if (r.length) return next()
+    if (r.fcrdns && r.fcrdns.length) return next()
 
     if (plugin.cfg.reject.no_fcrdns) {
         return next(DENY, 'Sorry, no FCrDNS match found')

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ exports.check_fcrdns = function (connection, results, next) {
 
     const r = connection.results.get('fcrdns')
     if (!r) return next()
-    if (r.length) return next()
+    if (r.fcrdns && r.fcrdns.length) return next()
 
     if (plugin.cfg.reject.no_fcrdns) {
         return next(DENY, 'Sorry, no FCrDNS match found')

--- a/index.js
+++ b/index.js
@@ -206,12 +206,7 @@ exports.check_fcrdns = function (connection, results, next) {
         }
 
         // FCrDNS? PTR -> (A | AAAA) 3. PTR comparison
-        if (Array.isArray(results[fdom])) {
-            plugin.ptr_compare(results[fdom], connection, fdom)
-        }
-        else {
-            plugin.ptr_compare([results[fdom]], connection, fdom)
-        }
+        plugin.ptr_compare(results[fdom], connection, fdom)
 
         connection.results.add(plugin, {ptr_name_has_ips: true})
 
@@ -228,7 +223,7 @@ exports.check_fcrdns = function (connection, results, next) {
 
     const r = connection.results.get('fcrdns')
     if (!r) return next()
-    if (r.fcrdns && r.fcrdns.length) return next()
+    if (r.length) return next()
 
     if (plugin.cfg.reject.no_fcrdns) {
         return next(DENY, 'Sorry, no FCrDNS match found')


### PR DESCRIPTION
If no_fcrdns == true then domains with fcrdns were being rejected. Objects don't have a length property and the test really should be to see if a fcrdns exists. I would have also written a test but I don't understand the text fixture well enough yet.

Also, ptr_compare was sometimes passed a string and other times an array. When a string was passed, each character of the string was being pushed into the results. I added a check to see if it was a string and if so, passed it as an array. This is also an issue with the function same_ipv4_network in haraka-net-utils.
