### PR TITLE
Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_test:
   - npm --version
 
 test_script:
-  - C:\projects\haraka-plugin-fcrdns\node_modules\.bin\mocha
+  - npm test
 
 after_test:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_test:
   - npm --version
 
 test_script:
-  - npm test
+  - node_modules\.bin\_mocha
 
 after_test:
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Haraka plugin that checks a remote for Forward Confirmed reverse DNS",
   "main": "index.js",
   "scripts": {
-    "lint": "node node_modules/.bin/eslint *.js test/*.js",
-    "lintfix": "node node_modules/.bin/eslint --fix *.js test/*.js",
-    "test": "node node_modules/.bin/mocha"
+    "lint": "./node_modules/.bin/eslint *.js test/*.js",
+    "lintfix": "./node_modules/.bin/eslint --fix *.js test/*.js",
+    "test": "./node_modules/.bin/_mocha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Haraka plugin that checks a remote for Forward Confirmed reverse DNS",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint *.js test/*.js",
-    "lintfix": "./node_modules/.bin/eslint --fix *.js test/*.js",
-    "test": "./node_modules/.bin/_mocha"
+    "lint": "node node_modules/.bin/eslint *.js test/*.js",
+    "lintfix": "node node_modules/.bin/eslint --fix *.js test/*.js",
+    "test": "node node_modules/.bin/_mocha"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -208,7 +208,6 @@ describe('check_fcrdns', function () {
 })
 
 describe('do_dns_lookups', function () {
-    this.timeout(4000);
 
     const testIps = {
         '8.8.4.4': 'google.com',
@@ -221,6 +220,7 @@ describe('do_dns_lookups', function () {
     Object.keys(testIps).forEach((ip) => {
 
         it(`looks up ${ip}`, function (done) {
+            this.timeout(4000);
 
             const conn = this.connection
             conn.remote.ip = ip
@@ -239,7 +239,7 @@ describe('do_dns_lookups', function () {
 })
 
 describe('resolve_ptr_names', function () {
-    this.timeout(4000);
+    this.timeout(5000);
 
     it('gets IPs from valid host names', function (done) {
         const ptr_names = [ 'mail.theartfarm.com' ]

--- a/test/index.js
+++ b/test/index.js
@@ -208,6 +208,7 @@ describe('check_fcrdns', function () {
 })
 
 describe('do_dns_lookups', function () {
+    this.timeout(4000);
 
     const testIps = {
         '8.8.4.4': 'google.com',
@@ -238,6 +239,8 @@ describe('do_dns_lookups', function () {
 })
 
 describe('resolve_ptr_names', function () {
+    this.timeout(4000);
+
     it('gets IPs from valid host names', function (done) {
         const ptr_names = [ 'mail.theartfarm.com' ]
         this.plugin.resolve_ptr_names(ptr_names, this.connection, () => {


### PR DESCRIPTION
Fixes this problem, which occurs when appveyor runs the npm script it drops in ./node_modules/bin/mocha. The mocha script has this description:

```
/**
 * This tiny wrapper file checks for known node flags and appends them
 * when found, before invoking the "real" _mocha(1) executable.
 */
```

And results in this when it runs:

````
> haraka-plugin-fcrdns@1.0.3 test C:\projects\haraka-plugin-fcrdns
18> node node_modules/.bin/mocha
19
20C:\projects\haraka-plugin-fcrdns\node_modules\.bin\mocha:2
21basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
22          ^^^^^^^
23
24SyntaxError: missing ) after argument list
25    at createScript (vm.js:80:10)
26    at Object.runInThisContext (vm.js:139:10)
27    at Module._compile (module.js:617:28)
28    at Object.Module._extensions..js (module.js:664:10)
29    at Module.load (module.js:566:32)
30    at tryModuleLoad (module.js:506:12)
31    at Function.Module._load (module.js:498:3)
32    at Function.Module.runMain (module.js:694:10)
33    at startup (bootstrap_node.js:204:16)
34    at bootstrap_node.js:625:3
35npm ERR! Test failed.  See above for more details.
36
````