### PR TITLE
drop node 6 CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-    - "6"
     - "8"
     - "10"
+    - "12"
 
 services:
 # https://docs.travis-ci.com/user/database-setup/

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ exports.do_dns_lookups = function (next, connection) {
         connection.logdebug(plugin, `rdns.reverse(${rip})`)
         if (err) return plugin.handle_ptr_error(connection, err, nextOnce)
 
-        connection.results.add(plugin, {ptr_names: ptr_names})
+        connection.results.add(plugin, {ptr_names})
         connection.results.add(plugin, {has_rdns: true})
 
         plugin.resolve_ptr_names(ptr_names, connection, nextOnce);

--- a/test/index.js
+++ b/test/index.js
@@ -210,8 +210,8 @@ describe('check_fcrdns', function () {
 describe('do_dns_lookups', function () {
 
     const testIps = {
-        '8.8.4.4': 'google.com',
-        '2001:4860:4860::8844': 'google.com',
+        '8.8.4.4': 'dns.google',
+        '2001:4860:4860::8844': 'dns.google',
         '4.2.2.2': 'level3.net',
         '208.67.222.222': 'opendns.com',
         // '2001:428::1': 'qwest.net',


### PR DESCRIPTION
fixes #23 

- drop node 6 CI testing
- update rDNS tests for google from google.com to dns.google.