### PR TITLE
Don't consider ENODATA as error when performing PTR lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ exports.handle_ptr_error = function (connection, err, next) {
     switch (err.code) {
         case dns.NOTFOUND:
         case dns.NXDOMAIN:
+        case dns.NODATA:
             connection.results.add(plugin, {fail: 'has_rdns', emit: true})
             if (!plugin.cfg.reject.no_rdns) return next()
             if (plugin.is_whitelisted((connection))) return next()


### PR DESCRIPTION
Because NODATA error means there was no meaningful data returned from resolver, which usually means it's an error on client side, not on resolver/DNS server side.

Take 187.109.46.51  that is incorrectly configured with CNAME while it should've been a domain name. It returns ENODATA over here for it.