### PR TITLE
fix: reduce log noise from same_ipv4_network

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 // build in node modules
 const dns       = require('dns')
+const net       = require('net')
 
 // NPM modules
 const constants = require('haraka-constants')
@@ -249,7 +250,8 @@ exports.ptr_compare = function (ip_list, connection, domain) {
         connection.results.push(plugin, {fcrdns: domain})
         return true
     }
-    if (net_utils.same_ipv4_network(connection.remote.ip, ip_list)) {
+    const ip_list_ipv4 = ip_list.filter(net.isIPv4)
+    if (ip_list_ipv4.length && net_utils.same_ipv4_network(connection.remote.ip, ip_list_ipv4)) {
         connection.results.add(plugin, {pass: 'fcrdns(net)' })
         connection.results.push(plugin, {fcrdns: domain})
         return true


### PR DESCRIPTION
The net_utils.same_ipv4_network function calls console.error if given a
non-ipv4 address:

        same_ipv4_network, IP in list is not IPv4!'

The ip_list input to that function comes from get_ips_by_host, whose
output is the result of both resolve4 and resolve6. So for
same_ipv4_network not to generate log noise, we need to filter its
input.